### PR TITLE
Update YouTube parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Usage
 
 ::
 
-    Hey there, check out this rad new song:
+    Hey there, check out this rad song on Spotify:
     [spotify uri=spotify:track:41eiwHEX8iegmqmS2cf7oX]
 
 Available parameters:
@@ -42,6 +42,20 @@ Available parameters:
 * ``view``: View styles of the embed, either 'list', 'coverart'.
 
 Parameters are implemented as documented here: https://developer.spotify.com/technologies/widgets/spotify-play-button/
+
+**Soundcloud**
+
+::
+
+    Oh hi, check out this rad song on Soundcloud:
+    [soundcloud url=https://soundcloud.com/epitaph-records/the-menzingers-thick-as-thieves]
+
+Available parameters:
+
+* ``url`` (required): The URL for the Soundcloud track or collection that you'd like to embed.
+* ``width``: The width of the embed. If not set, 480 is the default.
+* ``height``: The height of the embed. If not set, 166 is the default.
+* ``color``: Optionally specify a button color in hex format without the `#` character, e.g. `c0ff33`.
 
 Settings
 ========

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,24 @@ Usage
     {% load shortcodes_filters %}
     {{ text|shortcodes|safe }}
 
+
+**Spotify**
+
+::
+
+    Hey there, check out this rad new song:
+    [spotify uri=spotify:track:41eiwHEX8iegmqmS2cf7oX]
+
+Available parameters:
+
+* ``uri`` (required): The Spotify URI for a track, album, playlist, etc., that you'd like to embed. This can be found in the Spotify app with "Copy Spotify URI" buttons.
+* ``width``: The width of the embed. If not set, 480 is the default.
+* ``height``: The height of the embed. If not set, 480 is the default.
+* ``theme``: Color theme of the embed, either 'black' or 'white'
+* ``view``: View styles of the embed, either 'list', 'coverart'.
+
+Parameters are implemented as documented here: https://developer.spotify.com/technologies/widgets/spotify-play-button/
+
 Settings
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,6 @@ Vimeo
 YouTube
 -------
 
-- ``SHORTCODES_YOUTUBE_JQUERY``: Boolean whether the
-  `jquery.flash plugin <https://github.com/Qard/jquery-flash>`_ is
-  available.
 - ``SHORTCODES_YOUTUBE_HEIGHT``: Default height for YouTube videos.
 - ``SHORTCODES_YOUTUBE_WIDTH``: Default width for YouTube videos.
 

--- a/README.rst
+++ b/README.rst
@@ -42,3 +42,9 @@ YouTube
   available.
 - ``SHORTCODES_YOUTUBE_HEIGHT``: Default height for YouTube videos.
 - ``SHORTCODES_YOUTUBE_WIDTH``: Default width for YouTube videos.
+
+Spotify
+-------
+
+- ``SHORTCODES_SPOTIFY_WIDTH``: Default width for Spotify embeds, can be a number or a percentage, e.g. `80%`
+- ``SHORTCODES_SPOTIFY_HEIGHT``: Default height for Spotify embeds, can be a number or a percentage, e.g. `80%`

--- a/README.rst
+++ b/README.rst
@@ -66,3 +66,9 @@ Spotify
 
 - ``SHORTCODES_SPOTIFY_WIDTH``: Default width for Spotify embeds, can be a number or a percentage, e.g. `80%`
 - ``SHORTCODES_SPOTIFY_HEIGHT``: Default height for Spotify embeds, can be a number or a percentage, e.g. `80%`
+
+Soundcloud
+----------
+
+- ``SHORTCODES_SOUNDCLOUD_HEIGHT``: Default height for Soundcloud player embeds.
+- ``SHORTCODES_SOUNDCLOUD_WIDTH``: Default width for Soundcloud player embeds.

--- a/shortcodes/parsers/soundcloud.py
+++ b/shortcodes/parsers/soundcloud.py
@@ -1,0 +1,43 @@
+import re
+
+from django.template.loader import render_to_string
+from django.conf import settings
+
+DEFAULT_WIDTH = 480
+DEFAULT_HEIGHT = 166
+
+HEX_COLOR_REGEX = r'^([a-f0-9]{6}|[a-f0-9]{3})$'
+
+def parse(kwargs, template_name='shortcodes/soundcloud.html'):
+    """
+    Shortcode parser for Soundcloud player embed
+    https://soundcloud.com/pages/embed
+    """
+    url = kwargs.get('url')
+
+    if url:
+        width = kwargs.get(
+            'width',
+            getattr(settings, 'SHORTCODES_SOUNDCLOUD_WIDTH', DEFAULT_WIDTH)
+        )
+
+        height = kwargs.get(
+            'height',
+            getattr(settings, 'SHORTCODES_SOUNDCLOUD_HEIGHT', DEFAULT_HEIGHT)
+        )
+
+        color = kwargs.get('color')
+
+        if color and not re.match(HEX_COLOR_REGEX, color, flags=re.IGNORECASE):
+            color = None
+
+        ctx = {
+            'url': url,
+            'width': width,
+            'height': height
+        }
+
+        if color:
+            ctx['color'] = color
+
+        return render_to_string(template_name, ctx)

--- a/shortcodes/parsers/spotify.py
+++ b/shortcodes/parsers/spotify.py
@@ -1,0 +1,45 @@
+from django.template import Template, Context
+from django.template.loader import render_to_string
+from django.conf import settings
+
+THEME_OPTIONS = ('black', 'white',)
+VIEW_OPTIONS = ('list', 'coverart',)
+
+DEFAULT_WIDTH = 480
+DEFAULT_HEIGHT = 480
+
+def parse(kwargs, template_name='shortcodes/spotify.html'):
+    """
+    Shortcode parser for Spotify player embed. All options and markup referenced from:
+    https://developer.spotify.com/technologies/widgets/spotify-play-button/
+    """
+    uri = kwargs.get('uri')
+
+    if uri:
+        width = kwargs.get(
+            'width',
+            getattr(settings, 'SHORTCODES_SPOTIFY_WIDTH', DEFAULT_WIDTH)
+        )
+
+        height = kwargs.get(
+            'height',
+            getattr(settings, 'SHORTCODES_SPOTIFY_HEIGHT', DEFAULT_HEIGHT)
+        )
+
+        theme = kwargs.get('theme')
+        view = kwargs.get('view')
+
+        ctx = {
+            'uri': uri,
+            'width': width,
+            'height': height
+        }
+
+        if theme and theme in THEME_OPTIONS:
+            ctx['theme'] = theme
+
+        if view and view in VIEW_OPTIONS:
+            ctx['view'] = view
+
+        return render_to_string(template_name, ctx)
+

--- a/shortcodes/parsers/spotify.py
+++ b/shortcodes/parsers/spotify.py
@@ -1,4 +1,3 @@
-from django.template import Template, Context
 from django.template.loader import render_to_string
 from django.conf import settings
 

--- a/shortcodes/parsers/youtube.py
+++ b/shortcodes/parsers/youtube.py
@@ -25,6 +25,11 @@ class YoutubeParamForm(forms.Form):
     username = forms.CharField(required=False)
     query = forms.CharField(required=False)
 
+    # Embed size
+
+    width = forms.CharField(required=False)
+    height = forms.CharField(required=False)
+
     """
     YouTube embed parameters as taken from the documentation:
     https://developers.google.com/youtube/player_parameters#Parameters
@@ -47,8 +52,6 @@ class YoutubeParamForm(forms.Form):
     rel = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
     showinfo = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
     start = forms.IntegerField(min_value=1, required=False)
-    width = forms.CharField(required=False)
-    height = forms.CharField(required=False)
 
     def clean_width(self):
         width = self.cleaned_data.get('width')

--- a/shortcodes/parsers/youtube.py
+++ b/shortcodes/parsers/youtube.py
@@ -1,53 +1,112 @@
-from django.template import Template, Context
+import re
+from urllib import urlencode
+
+from django import forms
 from django.conf import settings
+from django.template.loader import render_to_string
 
+DEFAULT_WIDTH = 480
+DEFAULT_HEIGHT = 270
 
-def parse(kwargs):
-    id = kwargs.get('v')
-    width = int(kwargs.get(
-        'w',
-        getattr(settings, 'SHORTCODES_YOUTUBE_WIDTH', 480))
-    )
-    height = int(kwargs.get(
-        'h',
-        getattr(settings, 'SHORTCODES_YOUTUBE_HEIGHT', 385))
-    )
-    jquery = getattr(settings, 'SHORTCODES_YOUTUBE_JQUERY', False)
+def choicify(choice_tuple):
+    return tuple((val, val,) for val in choice_tuple)
 
-    if jquery:
-        html = '<a id="yt_{{ id }}"'
-        html += ' href="https://www.youtube.com/watch?v={{ id }}">'
-        html += '<span>Watch the YouTube video</span></a>\n'
-        html += '<script type="text/javascript">\n'
-        html += '\t$("#yt_{{ id }}").flash(\n'
-        html += '\t\t{\n'
-        html += '\t\t\tsrc: "https://www.youtube.com/v/{{ id }}",\n'
-        html += '\t\t\twidth: {{ width }},\n'
-        html += '\t\t\theight: {{ height }}\n'
-        html += '\t\t}\n'
-        html += '\t);\n'
-        html += '\t$("#yt_{{ id }} span").hide()\n'
-        html += '</script>\n'
-    else:
-        html = '<object width="{{ width }}" height="{{ height }}">'
-        html += '<param name="movie" value="https://www.youtube.com/v/{{ id }}'
-        html += '&hl=en&fs=1"></param>'
-        html += '<param name="allowFullScreen" value="true"></param>'
-        html += '<param name="allowscriptaccess" value="always"></param>'
-        html += '<embed src="https://www.youtube.com/v/{{ id }}&hl=en&fs=1" '
-        html += 'type="application/x-shockwave-flash" '
-        html += 'allowscriptaccess="always" allowfullscreen="true" '
-        html += 'width="{{ width }}" height="{{ height }}"></embed>'
-        html += '</object>'
+TRUTHY_CHOICES = choicify(('0', '1',))
 
-    template = Template(html)
-    context = Context({
-        'id': id,
-        'width': width,
-        'height': height
-    })
+class YoutubeParamForm(forms.Form):
+    """
+    These are shorthand/convenience parameters, `v` and `id` being synonymous (for a single video id)
+    and `playlist_id`, `username`, `query` being shorthand for a playlist embed, YouTube user channel
+    embed, and a search result embed, respectively
+    """
+    v = forms.CharField(required=False)
+    id = forms.CharField(required=False)
+    playlist_id = forms.CharField(required=False)
+    username = forms.CharField(required=False)
+    query = forms.CharField(required=False)
 
-    if id:
-        return template.render(context)
-    else:
-        return 'Video not found'
+    """
+    YouTube embed parameters as taken from the documentation:
+    https://developers.google.com/youtube/player_parameters#Parameters
+    """
+
+    autoplay = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    color = forms.ChoiceField(choices=choicify(('red', 'white',)), required=False)
+    controls = forms.ChoiceField(choices=choicify(('0', '1', '2',)), required=False)
+    cc_load_policy = forms.ChoiceField(choices=choicify(('1',)), required=False)
+    disablekb = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    end = forms.IntegerField(min_value=1, required=False)
+    fs = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    hl = forms.RegexField(regex=r'^[a-z]{2}$', required=False)
+    iv_load_policy = forms.ChoiceField(choices=choicify(('1', '3',)), required=False)
+    listType = forms.ChoiceField(choices=choicify(('playlist', 'search', 'user_uploads',)), required=False)
+    loop = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    modestbranding = forms.ChoiceField(choices=choicify(('1',)), required=False)
+    playlist = forms.CharField(required=False)
+    playsinline = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    rel = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    showinfo = forms.ChoiceField(choices=TRUTHY_CHOICES, required=False)
+    start = forms.IntegerField(min_value=1, required=False)
+    width = forms.CharField(required=False)
+    height = forms.CharField(required=False)
+
+    def clean_width(self):
+        width = self.cleaned_data.get('width')
+        if not width:
+            return getattr(settings, 'SHORTCODES_YOUTUBE_WIDTH', DEFAULT_WIDTH)
+        return width
+
+    def clean_height(self):
+        height = self.cleaned_data.get('height')
+        if not height:
+            return getattr(settings, 'SHORTCODES_YOUTUBE_HEIGHT', DEFAULT_HEIGHT)
+        return height
+
+    def clean(self):
+        data = super(YoutubeParamForm, self).clean()
+
+        video_id = data.get('v') or data.get('id')
+        playlist_id = data.get('playlist_id')
+        username = data.get('username')
+        query = data.get('query')
+
+        if any([video_id, playlist_id, username, query]):
+            if video_id:
+                data['video_id'] = video_id
+            elif playlist_id:
+                data['list'] = playlist_id
+                data['listType'] = 'playlist'
+            elif username:
+                data['list'] = username
+                data['listType'] = 'user_uploads'
+            elif query:
+                data['list'] = query
+                data['listType'] = 'search'
+
+            return data
+        else:
+            raise forms.ValidationError('Must set a video id, playlist id or username for YouTube shortcode')
+
+def parse(kwargs, template_name='shortcodes/youtube.html'):
+    form = YoutubeParamForm(kwargs)
+
+    if form.is_valid():
+
+        # Pull out cleaned data, filtering out empty values
+        
+        data = dict((k, v) for k, v in form.cleaned_data.iteritems() if v)
+
+        # Pop these out, leaving the remaining keys for the query string
+
+        for key in ['playlist_id', 'username', 'query']:
+            data.pop(key, None)
+
+        ctx = {
+            'video_id': data.pop('video_id', None),
+            'width': data.pop('width'),
+            'height': data.pop('height')
+        }
+
+        ctx['query_string'] = urlencode(data)
+
+        return render_to_string(template_name, ctx)

--- a/shortcodes/templates/shortcodes/soundcloud.html
+++ b/shortcodes/templates/shortcodes/soundcloud.html
@@ -1,0 +1,7 @@
+<iframe
+  width="{{ width }}"
+  height="{{ height }}"
+  scrolling="no"
+  frameborder="no"
+  src="https://w.soundcloud.com/player/?url={{ url|urlencode }}{% if color %}&amp;color={{ color }}{% endif %}">
+</iframe>

--- a/shortcodes/templates/shortcodes/spotify.html
+++ b/shortcodes/templates/shortcodes/spotify.html
@@ -1,0 +1,7 @@
+<iframe
+  src="https://embed.spotify.com/?uri={{ uri }}{% if theme %}&amp;theme={{ theme }}{% endif %}{% if view %}&amp;view={{ view }}{% endif %}"
+  width="{{ width }}"
+  height="{{ height }}"
+  frameborder="0"
+  allowtransparency="true">
+</iframe>

--- a/shortcodes/templates/shortcodes/youtube.html
+++ b/shortcodes/templates/shortcodes/youtube.html
@@ -1,0 +1,7 @@
+<iframe
+  width="{{ width }}"
+  height="{{ height }}"
+  src="https://www.youtube.com/embed{% if video_id %}/{{ video_id }}{% endif %}{% if query_string %}?{{ query_string|safe }}{% endif %}"
+  frameborder="0"
+  allowfullscreen>
+</iframe>


### PR DESCRIPTION
Here's another PR for an overhaul of the YouTube parser that removes the jQuery setting that was in there previously (the plugin this was referencing looked pretty old/abandoned), moved the rendering into a template, implements all of the available parameters for YouTube embeds as documented here: https://developers.google.com/youtube/player_parameters#Parameters, and validates everything via a form class. I realize I'm bulldozing a lot here, but totally open to your feedback, etc., and happy to start fresh if there's a different direction you think this should go. I'm already wondering if it might be better not to validate specific parameters like I have it doing and just pass everything left over in kwargs on to the query string of the embed.

And I haven't heard from you on the other 2 PRs, so I'm not sure if you're still active on this or not. I'm probably just going to merge everything into my fork and pip install from GitHub, but I'd love to collaborate on this if you're open to that. Thanks!